### PR TITLE
adds put /items/:id route to update an item and refactors the itemrep…

### DIFF
--- a/src/controllers/ItemController.ts
+++ b/src/controllers/ItemController.ts
@@ -14,18 +14,17 @@ export const getOne = async (item_id: number) : Promise<Items | null> => {
     return result
 }
 
-
-export const addItem = async (body: object) : Promise<object> => {
+export const saveItem = async (body: object, item_id: number = null) : Promise<object> => {
     let itemRepository = new ItemRepository()
-    let locationRepository = new LocationRepository()
     try {
-        let location = null
-        let existingLocation = await locationRepository.getOne(body['location'])
-        if (!existingLocation) {
-            location = await locationRepository.createLocation(body['location'])
+        if (item_id) {
+            let item = await getOne(item_id)
+            if (!item) {
+                throw new Error(`Item of id ${item_id} does not exist`)
+            }
         }
-        body['location'] = location ? location['location_id'] : existingLocation['location_id']
-        let result = await itemRepository.createItem(body)
+        body['location'] = await getLocation(body['location'])
+        let result = await itemRepository.saveItem(body, item_id)
         return {
             "success": true,
             "body": result
@@ -36,4 +35,14 @@ export const addItem = async (body: object) : Promise<object> => {
             "error": error.message 
         }
     }
+}
+
+const getLocation = async (locationObj: object) => {
+    let locationRepository = new LocationRepository()
+    let location = null
+    let existingLocation = await locationRepository.getOne(locationObj)
+    if (!existingLocation) {
+        location = await locationRepository.createLocation(locationObj)
+    }
+    return location ? location['location_id'] : existingLocation['location_id']
 }

--- a/src/models/repository/ItemRepository.ts
+++ b/src/models/repository/ItemRepository.ts
@@ -1,8 +1,6 @@
 import "reflect-metadata"
 import { AppDataSource } from "../data-source"
 import { Items } from "../../entity/items"
-import { Locations } from "../../entity/locations"
-import { FindOneOptions } from "typeorm"
 
 export class ItemRepository {
     getAll = async () : Promise<Items[]> => {
@@ -31,7 +29,7 @@ export class ItemRepository {
         }
     }
 
-    createItem = async (validatedItem: object) : Promise<object> => {
+    saveItem = async (validatedItem: object, item_id?: number) : Promise<object> => {
         try {
             await AppDataSource.initialize()
             let item = new Items()
@@ -44,6 +42,7 @@ export class ItemRepository {
             item.availability = validatedItem['availability']
             item.location = validatedItem['location']
             item.reputation_badge = this.generateReputationBadge(validatedItem['reputation'])
+            item.item_id = Number(item_id)
             await AppDataSource.manager.save(item)
             await AppDataSource.destroy()
             return item

--- a/src/routes/item.ts
+++ b/src/routes/item.ts
@@ -23,8 +23,21 @@ router.post('/', locationValidator, itemValidator, async (req: Request, res: Res
         return res.status(400).json({ errors: errors.array() })
     }
     try {
-        let result = await itemController.addItem(req.body)
+        let result = await itemController.saveItem(req.body)
         res.status(201).json({'body': result})
+    } catch (error) {
+        res.status(error.code ?? 500).send(error.message)
+    }
+})
+
+router.put('/:id', locationValidator, itemValidator, async (req: Request, res: Response) => {
+    const errors = validationResult(req)
+    if (!errors.isEmpty()) {
+        return res.status(400).json({ errors: errors.array() })
+    }
+    try {
+        let result = await itemController.saveItem(req.body, req.params.id)
+        res.status(200).json({'body': result})
     } catch (error) {
         res.status(error.code ?? 500).send(error.message)
     }


### PR DESCRIPTION
# Changelog:
- Added route PUT /items/:id to update existing items;
- It is also now possible to update an item's location data. If the location being updated doesn't exist, the system creates a new one and updates the location_id on the Item entry;
- Refactored how createItem and updateItem works so that they use the same method.